### PR TITLE
Fix segfault when calling realloc on body array

### DIFF
--- a/main.c
+++ b/main.c
@@ -270,7 +270,7 @@ MemResult system_init(System *system) {
 
 MemResult system_realloc(System *system) {
   size_t new_capacity = system->capacity * 2;
-  Body *bodies = realloc(system->bodies, new_capacity * sizeof(Body *));
+  Body *bodies = realloc(system->bodies, new_capacity * sizeof(Body));
   if (bodies == NULL) {
     printf("ERROR: Could not re-allocate memory for system\n");
     return NOT_ENOUGH_MEMORY;


### PR DESCRIPTION
The array was previously reallocated to fit the size of a Body pointer rather than the desired size of Body